### PR TITLE
chore: Add GPT-4.1 Search Similarity Scoring with Cost Tracking for Accepted Prompts

### DIFF
--- a/core/orchestration/generate_batch.py
+++ b/core/orchestration/generate_batch.py
@@ -105,6 +105,12 @@ def _generate_and_validate_prompt(config, cost_tracker):
                         "similarity_score": similarity.get("similarity_score"),
                         "top_matches": similarity.get("top_matches", [])
                     }
+                    cost_tracker.log(
+                        {"provider": "openai", "model_name": "gpt-4.1"},
+                        similarity.get("tokens_prompt", 0),
+                        similarity.get("tokens_completion", 0),
+                    )
+
                     log_info(f"🔍 Similarity score: {core['similar_problems']['similarity_score']:.3f}")
                 except Exception as e:
                     log_error("⚠️ Error scoring similarity", exception=e)

--- a/core/search/agent.py
+++ b/core/search/agent.py
@@ -24,6 +24,7 @@ def score_with_llm(problem_text, retrieved_docs, model="gpt-4.1"):
     """
     Calls an LLM to evaluate how similar a synthetic math problem is
     to a list of real-world math questions (title + content).
+    Returns both similarity data and token usage.
     """
     payload = {
         "problem": problem_text,
@@ -36,5 +37,7 @@ def score_with_llm(problem_text, retrieved_docs, model="gpt-4.1"):
     parsed = safe_json_parse(response["output"])
     return {
         "similarity_score": parsed.get("similarity_score", 0.0),
-        "top_matches": parsed.get("matches", [])
+        "top_matches": parsed.get("matches", []),
+        "tokens_prompt": response.get("tokens_prompt", 0),
+        "tokens_completion": response.get("tokens_completion", 0)
     }


### PR DESCRIPTION
This pull request integrates the search similarity agent into the synthetic prompt generation pipeline. Specifically:

✅ Calls the Tavily search agent and GPT-4.1 similarity scorer only for accepted prompts (where the target model fails).

💰 Tracks token usage and logs cost for the similarity scorer using the existing CostTracker utility.

🛡️ Handles fallback behavior if the similarity agent fails, ensuring pipeline robustness.

🔧 Fixes a key mismatch in the cost logging config (model ➝ model_name) for proper accounting.

🔬 Prepares the system for deeper analysis of prompt novelty via similarity_score and top_matches.

This enhancement enables richer metadata and accurate cost tracking without impacting rejected or invalid prompts.